### PR TITLE
Initial set of changes before going live

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <title>Flashbots</title>
   <link rel="stylesheet" href="styles.css">
-  <script src="scripts.js"></script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
       <h2>MEV-Share CTF</h2>
       <p>August 5-6</p>
     </div>
-    <a class="button" href="https://forms.gle/M4GQ5Pr53xebhZbv9" target="_blank">Register here</a>
+    <div class="tab">More soon…</div>
   </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -34,8 +34,12 @@
 
   <div class="content">
     <div>
-      <p>August 5-6</p>
       <h2><a href="https://docs.flashbots.net/flashbots-mev-share/overview" target="_blank">MEV-Share CTF</a></h2>
+      <p class="dates">
+        2023-08-05 T 00:00:00.000Z<br>
+        <span>⇣</span><br>
+        2023-08-07 T 00:00:00.000Z
+      </p>
     </div>
     <div class="tab">More soon…</div>
   </div>

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
 
   <div class="content">
     <div>
-      <h2>MEV-Share CTF</h2>
       <p>August 5-6</p>
+      <h2><a href="https://docs.flashbots.net/flashbots-mev-share/overview" target="_blank">MEV-Share CTF</a></h2>
     </div>
     <div class="tab">More soon…</div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,16 @@ p {
   text-align: center;
   width: 100%;
 }
+
+.tab {
+  color: white;
+  text-decoration: none;
+  font-size: .9rem;
+  border: solid 1px white;
+  border-radius: 2rem;
+  padding: .3rem .8rem;
+}
+
 .button {
   /* position: absolute; */
   /* bottom: 9rem; */

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,16 @@ h2 {
 }
 p {
   font-style: italic;
+
+h2 > a {
+  color: inherit;
+  text-decoration: none;
+}
+
+h2 > a:hover {
+  text-decoration: underline;
+}
+
   text-align: center;
   width: 100%;
 }

--- a/styles.css
+++ b/styles.css
@@ -73,8 +73,6 @@ h2 {
   margin: 0 0 1rem;
   font-size: 2rem;
 }
-p {
-  font-style: italic;
 
 h2 > a {
   color: inherit;
@@ -85,8 +83,15 @@ h2 > a:hover {
   text-decoration: underline;
 }
 
+p.dates {
+  font-family: monospace;
   text-align: center;
-  width: 100%;
+  font-size: medium;
+  font-weight: lighter;
+}
+
+p.dates > span {
+  font-size:x-large;
 }
 
 .tab {


### PR DESCRIPTION
After a conversation with Fred and Shea we decided on a handful of changes to the initial layout:

1. **Remove the link to Google Forms**
  We're not going to use the original Google Form - going instead with something more customizable. So the link at the bottom of the page was removed and the text replaced with  "More soon…"
2. **Add link to MEV-Share documentation**
  A link to the [MEV-Share docs](https://docs.flashbots.net/flashbots-mev-share/overview) was added to the main page title
3. **Change the date formats**
  Replaced the "Aug 5-6" copy with a fancier timestamp in GMT (e.g. `2023-08-05 T 00:00:00.000Z`)

This is how things look now:
<img width="536" alt="image" src="https://github.com/flashbots/ctf-website/assets/68292774/a31dd145-64d2-4f9f-8dd3-876243a42756">
