### PR TITLE
SEO: Fix link to MEV Share docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 
     <div class="content">
       <div>
-        <h2><a href="https://docs.flashbots.net/flashbots-mev-share/overview" target="_blank">MEV-Share CTF</a></h2>
+        <h2><a href="https://docs.flashbots.net/flashbots-mev-share/introduction" rel="noreferrer" target="_blank">MEV-Share CTF</a></h2>
         <p class="dates">
           2023-08-05 T 00:00:00.000Z<br>
           <span>⇣</span><br>


### PR DESCRIPTION
Fixing a rotten link to the MEV Share docs, as instructed by the SEO report

---
Task: [Link Errors](https://docs.google.com/presentation/d/1zRznWdOHz9ijfv-TOfkGSjqHv5gAFSETFtJ-e1d6wvI/edit#slide=id.g23787afad68_1_60)

Following the SEO guide here: https://docs.google.com/spreadsheets/d/13Xa_TKfuKrWzrK0zCgJNnQPXFK95hiBxqnLWE7cvHN8/edit#gid=1433029980